### PR TITLE
Update 05_transport.md

### DIFF
--- a/zh_cn/chapter_02/05_transport.md
+++ b/zh_cn/chapter_02/05_transport.md
@@ -144,7 +144,7 @@ TLS 配置。TLS 由 Golang 提供，支持 TLS 1.3，不支持 DTLS。
 
 > `disableSystemRoot`: true | false
 
-（V2Ray 4.18+）是否禁用操作系统自带的 CA 证书。默认值为 `false`。当值为 `true` 时，V2Ray 只会使用 `certificates` 中指定的证书进行 TLS 握手。
+（V2Ray 4.18+）是否禁用操作系统自带的 CA 证书。默认值为 `false`。当值为 `true` 时，V2Ray 只会使用 `certificates` 中指定的证书进行 TLS 握手。当值为 `false` 时，V2Ray 只会使用操作系统自带的 CA 证书进行 TLS 握手。
 
 > `certificates`: \[ [CertificateObject](#certificateobject) \]
 


### PR DESCRIPTION
经实际测试，在 "disableSystemRoot"选项的值设为"false"的情况下（启用操作系统自带的 CA 证书），V2Ray 会仅使用操作系统自带的证书库进行握手验证，忽略用户在配置文件"certificates" 中额外指定的证书。

原文未对"disableSystemRoot"选项的"false"值进行描述，这可能使读者错误地认为，在"false"值的情况下， V2Ray 会同时使用操作系统自带的 CA 证书 以及 配置文件"certificates" 中额外指定的证书进行握手验证。